### PR TITLE
Refactor label creation, add 'Release' PR support

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,27 +1,27 @@
-repo = github.pr_json[:base][:repo][:full_name]
-pr_number = github.pr_json[:number]
+REPO = github.pr_json[:base][:repo][:full_name]
+PR_NUMBER = github.pr_json[:number]
 
 # HELPERS
 # repo
-def repo_has_label?(repo, label)
-  github.api.labels(repo).any? { |l| l[:name] == label }
+def repo_has_label?(label)
+  github.api.labels(REPO).any? { |l| l[:name] == label }
 end
 
-def add_label_to_repo!(repo, label, color)
-  github.api.add_label(repo, label, color)
+def add_label_to_repo!(label, color)
+  github.api.add_label(REPO, label, color)
 end
 
 # issues
-def issue_has_label?(repo, pr_number, label)
-  github.api.labels_for_issue(repo, pr_number).any? { |l| l[:name] == label }
+def issue_has_label?(label)
+  github.api.labels_for_issue(REPO, PR_NUMBER).any? { |l| l[:name] == label }
 end
 
-def add_labels_to_issue!(repo, pr_number, labels)
-  github.api.add_labels_to_an_issue(repo, pr_number, labels)
+def add_label_to_issue!(label)
+  github.api.add_labels_to_an_issue(REPO, PR_NUMBER, [label])
 end
 
-def remove_label_from_issue!(repo, pr_number, label)
-  github.api.remove_label(repo, pr_number, label)
+def remove_label_from_issue!(label)
+  github.api.remove_label(REPO, PR_NUMBER, label)
 end
 
 # LABELS
@@ -33,39 +33,39 @@ labels = [
   {name: 'release', color: '336694'},
 ]
 labels.each do |lbl|
-  unless repo_has_label?(repo, lbl[:name])
-    add_label_to_repo!(repo, lbl[:name], lbl[:color])
+  unless repo_has_label?(lbl[:name])
+    add_label_to_repo!(lbl[:name], lbl[:color])
   end
 end
 
 if github.pr_title.downcase.start_with? 'release'
   # add/remove release label
   is_release = true
-  if !issue_has_label?(repo, pr_number, 'release')
-    add_labels_to_issue!(repo, pr_number, ['release'])
+  if !issue_has_label?('release')
+    add_label_to_issue!('release')
   end
 else
   is_release = false
 
   # add/remove tiny
-  issue_has_tiny_label = issue_has_label?(repo, pr_number, 'tiny')
+  issue_has_tiny_label = issue_has_label?('tiny')
   if git.lines_of_code < 50 && !issue_has_tiny_label
-    add_labels_to_issue!(repo, pr_number, ['tiny'])
+    add_label_to_issue!('tiny')
   elsif git.lines_of_code > 50 && issue_has_tiny_label
-    remove_label_from_issue!(repo, pr_number, 'tiny')
+    remove_label_from_issue!('tiny')
   end
 
   # add/remove please review
-  if !issue_has_label?(repo, pr_number, 'reviewed') && !issue_has_label?(repo, pr_number, 'please review')
-    add_labels_to_issue!(repo, pr_number, ['please review'])
+  if !issue_has_label?('reviewed') && !issue_has_label?('please review')
+    add_label_to_issue!('please review')
   end
 end
 
 # add/remove wip
 if github.pr_title.include? 'WIP'
-  add_labels_to_issue!(repo, pr_number, ['wip'])
-elsif issue_has_label?(repo, pr_number, 'wip')
-  remove_label_from_issue!(repo, pr_number, 'wip')
+  add_label_to_issue!('wip')
+elsif issue_has_label?('wip')
+  remove_label_from_issue!('wip')
 end
 
 # WARNINGS

--- a/Dangerfile
+++ b/Dangerfile
@@ -25,10 +25,18 @@ def remove_label_from_issue!(repo, pr_number, label)
 end
 
 # LABELS
-# create tiny
-unless repo_has_label?(repo, 'tiny')
-  add_label_to_repo!(repo, 'tiny', 'f7c6c7')
+labels = [
+  {name: 'tiny', color: 'f7c6c7'},
+  {name: 'please review', color: 'fbca04'},
+  {name: 'reviewed', color: '0e8a16'},
+  {name: 'wip', color: '1d76db'},
+]
+labels.each do |lbl|
+  unless repo_has_label?(repo, lbl[:name])
+    add_label_to_repo!(repo, lbl[:name], lbl[:color])
+  end
 end
+
 # add/remove tiny
 issue_has_tiny_label = issue_has_label?(repo, pr_number, 'tiny')
 if git.lines_of_code < 50 && !issue_has_tiny_label
@@ -37,22 +45,11 @@ elsif git.lines_of_code > 50 && issue_has_tiny_label
   remove_label_from_issue!(repo, pr_number, 'tiny')
 end
 
-# create reviewed/please review
-unless repo_has_label?(repo, 'please review')
-  add_label_to_repo!(repo, 'please review', 'fbca04')
-end
-unless repo_has_label?(repo, 'reviewed')
-  add_label_to_repo!(repo, 'reviewed', '0e8a16')
-end
 # add/remove please review
 if !issue_has_label?(repo, pr_number, 'reviewed') && !issue_has_label?(repo, pr_number, 'please review')
   add_labels_to_issue!(repo, pr_number, ['please review'])
 end
 
-# create wip label
-unless repo_has_label?(repo, 'wip')
-  add_label_to_repo!(repo, 'wip', '1d76db')
-end
 # add/remove wip
 if github.pr_title.include? 'WIP'
   add_labels_to_issue!(repo, pr_number, ['wip'])


### PR DESCRIPTION
All labels are now in an array of hashes, hopefully makes those clearer.

Adds notion of a "Release" PR, we use them in iOS land to group together lots of PRs.